### PR TITLE
Added test saving functionality to all test types

### DIFF
--- a/server/controllers/cookieController.js
+++ b/server/controllers/cookieController.js
@@ -1,10 +1,12 @@
 const cookieController = {};
 
+// Middleware to initialize a cookie when user logs in
 cookieController.setSSIDCookie = (req, res, next) => {
   res.cookie('ssid', JSON.stringify(res.locals.userId).replace(/\"/g, ''));
   return next();
 };
 
+// Middleware to delete a cookie upon user logging out
 cookieController.deleteCookie = (req, res, next) => {
   res.clearCookie('ssid');
   return next();

--- a/server/controllers/sessionController.js
+++ b/server/controllers/sessionController.js
@@ -1,15 +1,18 @@
+// Import the session model that defines schema of session
 const Session = require('../models/sessionModel');
 
 const sessionController = {};
 
+// Middleware to initialize a session upon successful login
 sessionController.startSession = (req, res, next) => {
   Session.create({ cookieId: res.locals.userId }, (err, result) => {
     if (err && err.code !== 11000) return next(err);
-    res.locals.ssid = req.cookies.ssid;
+    res.locals.ssid = res.locals.userId;
     return next();
   });
 };
 
+// Middleware to end currently active sessions, if any
 sessionController.endSession = (req, res, next) => {
   Session.deleteMany({ cookieId: req.cookies.ssid }, (err) => {
     if (err) return next(err);
@@ -17,6 +20,7 @@ sessionController.endSession = (req, res, next) => {
   });
 };
 
+// Middleware to check if entered user is currently already logged in
 sessionController.isLoggedIn = (req, res, next) => {
   console.log('sessionController.isLoggedIn: req.cookies.ssid:', req.cookies.ssid);
   Session.find({ cookieId: req.cookies.ssid }, (err, data) => {

--- a/server/controllers/testStateController.js
+++ b/server/controllers/testStateController.js
@@ -1,7 +1,8 @@
+// Import test state model that defines the structure of test stored in DB
 const TestState = require('../models/testStateModel');
-
 const testStateController = {};
 
+// Middleware to upload a passed test into DB
 testStateController.upload = (req, res, next) => {
   TestState.create(
     {
@@ -17,10 +18,12 @@ testStateController.upload = (req, res, next) => {
   );
 };
 
+// Middleware too get all saved tests of current user and of selected type
 testStateController.getTests = (req, res, next) => {
   TestState.find({ userId: req.cookies.ssid, testType: req.params.testType }, (err, result) => {
+    // If an error occurs, invoke error handler with err object
     if (err) return next(err);
-    if (result.length === 0) return next('User Has No Saved Tests');
+    // Save resulting tests array to locals object
     res.locals.tests = result;
     return next();
   });

--- a/server/controllers/testStateController.js
+++ b/server/controllers/testStateController.js
@@ -4,7 +4,12 @@ const testStateController = {};
 
 testStateController.upload = (req, res, next) => {
   TestState.create(
-    { userId: req.cookies.ssid, testName: req.body.testName, testState: req.body.testState },
+    {
+      userId: req.cookies.ssid,
+      testName: req.body.testName,
+      testType: req.body.testType,
+      testState: req.body.testState,
+    },
     (err) => {
       if (err) return next('Upload Failed');
       return next();
@@ -13,7 +18,7 @@ testStateController.upload = (req, res, next) => {
 };
 
 testStateController.getTests = (req, res, next) => {
-  TestState.find({ userId: req.cookies.ssid }, (err, result) => {
+  TestState.find({ userId: req.cookies.ssid, testType: req.params.testType }, (err, result) => {
     if (err) return next(err);
     if (result.length === 0) return next('User Has No Saved Tests');
     res.locals.tests = result;

--- a/server/models/sessionModel.js
+++ b/server/models/sessionModel.js
@@ -1,16 +1,14 @@
+// Import mongoose for MongoDB object modeling
 const mongoose = require('mongoose');
+// Schema constructor
 const Schema = mongoose.Schema;
 
-/**
- * Check out the `createdAt` field below. This is set up to use Mongo's automatic document
- * expiration service by giving the Mongoose schema the `expires` property.
- * After 30 seconds, the session will automatically be removed from the collection!
- * (actually, Mongo's cleanup service only runs once per minute so the session
- * could last up to 90 seconds before it's deleted, but still pretty cool!)
- */
+// Initialize a new schema object for collection 'session'
 const sessionSchema = new Schema({
+  // Save user ID
   cookieId: { type: String, required: true, unique: true },
-  createdAt: { type: Date, expires: 120, default: Date.now },
+  // Save expiration for 30 mins
+  createdAt: { type: Date, default: Date.now },
 });
 
 module.exports = mongoose.model('Session', sessionSchema);

--- a/server/models/testStateModel.js
+++ b/server/models/testStateModel.js
@@ -1,13 +1,18 @@
+// Import mongoose for MongoDB object modeling
 const mongoose = require('mongoose');
-
+// Schema constructor
 const Schema = mongoose.Schema;
 
+// Initialize a new schema object for collection 'testState'
 const testStateSchema = new Schema({
+  // Save ID of user that saves test
   userId: { type: String, require: true },
+  // Save name of test as user input
   testName: { type: String, require: true },
+  // Save corresponding type of test
   testType: { type: String, require: true },
+  // Save test state object
   testState: { type: Object, require: true },
 });
-const TestState = mongoose.model('testState', testStateSchema);
 
-module.exports = TestState;
+module.exports = mongoose.model('testState', testStateSchema);

--- a/server/models/testStateModel.js
+++ b/server/models/testStateModel.js
@@ -5,7 +5,8 @@ const Schema = mongoose.Schema;
 const testStateSchema = new Schema({
   userId: { type: String, require: true },
   testName: { type: String, require: true },
-  testState: { type: Object },
+  testType: { type: String, require: true },
+  testState: { type: Object, require: true },
 });
 const TestState = mongoose.model('testState', testStateSchema);
 

--- a/server/models/userModel.js
+++ b/server/models/userModel.js
@@ -1,3 +1,4 @@
+// Import mongoose for MongoDB object modeling
 const mongoose = require('mongoose');
 
 const MONGO_URI =
@@ -10,11 +11,11 @@ mongoose
 
 const Schema = mongoose.Schema;
 
-// Schema and model for 'user' collection
+// Initialize a new schema object for collection 'user'
 const userSchema = new Schema({
+  // Save username and password of user
   username: { type: String, require: true, unique: true },
   password: { type: String, require: true },
 });
-const User = mongoose.model('user', userSchema);
 
-module.exports = User;
+module.exports = mongoose.model('user', userSchema);

--- a/server/routes/router.js
+++ b/server/routes/router.js
@@ -1,38 +1,73 @@
-const path = require('path');
+// Import Express to streamline server logic with router
 const express = require('express');
-
+// Import all relevant controller objects equipped with middleware
 const userController = require('../controllers/userController');
 const cookieController = require('../controllers/cookieController');
 const sessionController = require('../controllers/sessionController');
 const testStateController = require('../controllers/testStateController');
+// Initialize an express router
 const router = express.Router();
 
-router.post('/signup', userController.bcrypt, userController.signup, (req, res) => {
-  res.status(200).json('Sign Up Successful');
-});
+// Set up route for post requests to /signup
+router.post(
+  '/signup',
+  // Bcrypt middleware to encrypt user password
+  userController.bcrypt,
+  // Signup middleware to sign user up with encrypted credentials
+  userController.signup,
+  // Anonymous middleware to send back valid response
+  (req, res) => {
+    res.status(200).json('Sign Up Successful');
+  }
+);
 
+// Set up route for post requests to /login
 router.post(
   '/login',
+  // Login middleware checks encrypted credentials
   userController.login,
+  // Cookie middleware to set up a new cookie
   cookieController.setSSIDCookie,
+  // Session middleware to initialize new session
   sessionController.startSession,
+  // Anonymous middleware to send back valid response
   (req, res) => {
     res.status(200).json({ ssid: res.locals.ssid });
   }
 );
 
-router.get('/logout', sessionController.endSession, (req, res) => {
-  res.status(200).json('Logged Out Successfully');
-});
+// Set up route for get requests to /logout
+router.get(
+  '/logout',
+  // Session middleware to end any existing sessions
+  sessionController.endSession,
+  // Anonymous middleware to send back valid response
+  (req, res) => {
+    res.status(200).json('Logged Out Successfully');
+  }
+);
 
-router.post('/upload', sessionController.isLoggedIn, testStateController.upload, (req, res) => {
-  res.status(200).json('Test Uploaded Successfully');
-});
+// Set up route for post requests to /upload
+router.post(
+  '/upload',
+  // Session middleware to check if current user is signed in
+  sessionController.isLoggedIn,
+  // Upload middleware to save passed test object into DB
+  testStateController.upload,
+  // Anonymous middleware to send back valid response
+  (req, res) => {
+    res.status(200).json('Test Uploaded Successfully');
+  }
+);
 
+// Set up route for get requests to /getTests with type passed as param
 router.get(
   '/getTests/:testType',
+  // Session middleware to check if current user is signed in
   sessionController.isLoggedIn,
+  // GetTests middleware to retrieve all saved tests from DB
   testStateController.getTests,
+  // Anonymous middleware to send back valid response
   (req, res) => {
     res.status(200).json(res.locals.tests);
   }

--- a/server/routes/router.js
+++ b/server/routes/router.js
@@ -29,8 +29,13 @@ router.post('/upload', sessionController.isLoggedIn, testStateController.upload,
   res.status(200).json('Test Uploaded Successfully');
 });
 
-router.get('/getTests', sessionController.isLoggedIn, testStateController.getTests, (req, res) => {
-  res.status(200).json(res.locals.tests);
-});
+router.get(
+  '/getTests/:testType',
+  sessionController.isLoggedIn,
+  testStateController.getTests,
+  (req, res) => {
+    res.status(200).json(res.locals.tests);
+  }
+);
 
 module.exports = router;

--- a/src/components/AutoComplete/AutoCompleteMockData.jsx
+++ b/src/components/AutoComplete/AutoCompleteMockData.jsx
@@ -1,7 +1,11 @@
 import React, { useContext, useState } from 'react';
 import styles from '../AutoComplete/AutoCompleteMockData.module.scss';
 import AutoSuggest from 'react-autosuggest';
-import { updateAction, updateAssertion, updateProp } from '../../context/actions/reactTestCaseActions';
+import {
+  updateAction,
+  updateAssertion,
+  updateProp,
+} from '../../context/actions/reactTestCaseActions';
 import { MockDataContext } from '../../context/reducers/mockDataReducer';
 
 const AutoCompleteMockData = ({
@@ -12,6 +16,7 @@ const AutoCompleteMockData = ({
   renderId,
   propId,
   propKey,
+  propValue,
 }) => {
   let updatedAction = { ...statement };
   let updatedAssertion = { ...statement };
@@ -34,27 +39,27 @@ const AutoCompleteMockData = ({
     }
   };
 
-  mockData.forEach(mockDatum => {
-    let name = mockDatum.name.charAt(0).toUpperCase() + mockDatum.name.slice(1)
-    mockDatum.fieldKeys.forEach(key => {
+  mockData.forEach((mockDatum) => {
+    let name = mockDatum.name.charAt(0).toUpperCase() + mockDatum.name.slice(1);
+    mockDatum.fieldKeys.forEach((key) => {
       mockOptionsList.push({ value: `mock${name}.${key.fieldKey}` });
     });
     mockOptionsList.push({ value: `[mock${name}]` });
     mockOptionsList.push({ value: `{mock${name}}` });
   });
 
-  const getSuggestions = mockDataValue => {
-    const inputValue = mockDataValue.trim().toLowerCase();
-    const inputLength = inputValue.length;
-    return inputLength === 0 ? [] : mockOptionsList.filter(mockOption => mockOption.value);
+  const getSuggestions = (mockDataValue) => {
+    // const inputValue = mockDataValue.trim().toLowerCase();
+    const inputLength = 1;
+    return inputLength === 0 ? [] : mockOptionsList.filter((mockOption) => mockOption.value);
   };
 
   const shouldRenderSuggestions = () => {
     return true;
   };
 
-  const getSuggestionValue = suggestion => suggestion.value;
-  const renderSuggestion = suggestion => <div>{suggestion.value}</div>;
+  const getSuggestionValue = (suggestion) => suggestion.value;
+  const renderSuggestion = (suggestion) => <div>{suggestion.value}</div>;
 
   const onSuggestionsFetchRequested = ({ value }) => {
     setMockDataSuggestions(getSuggestions(value));
@@ -65,7 +70,7 @@ const AutoCompleteMockData = ({
 
   const inputProps = {
     placeholder: 'Enter or select a value.',
-    value: mockDataValue,
+    value: propValue,
     onChange: handleChangeValue,
   };
 

--- a/src/components/EndpointTestComponent/Endpoint.tsx
+++ b/src/components/EndpointTestComponent/Endpoint.tsx
@@ -136,6 +136,7 @@ const Endpoint = ({ endpoint, index, dispatchToEndpointTestCase }: EndpointProps
                   <input
                     type='text'
                     name='route'
+                    value={endpoint.route}
                     placeholder='eg. /route'
                     onChange={(e) => handleChangeEndpointFields(e, 'route')}
                   />

--- a/src/components/GetTests/GetTests.js
+++ b/src/components/GetTests/GetTests.js
@@ -12,7 +12,7 @@ const GetTests = ({ testType }) => {
   return (
     <>
       <button className={styles.getTestBtn} onClick={handleOpenGetTestsModal}>
-        Get Tests
+        Get Test
       </button>
       {getTestsModalIsOpen ? (
         <GetTestsModal

--- a/src/components/GetTests/GetTests.js
+++ b/src/components/GetTests/GetTests.js
@@ -12,7 +12,7 @@ const GetTests = ({ testType }) => {
   return (
     <>
       <button className={styles.getTestBtn} onClick={handleOpenGetTestsModal}>
-        Get Test
+        Get Tests
       </button>
       {getTestsModalIsOpen ? (
         <GetTestsModal

--- a/src/components/GetTests/GetTests.js
+++ b/src/components/GetTests/GetTests.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import styles from './GetTests.module.scss';
 import GetTestsModal from '../Modals/GetTestsModal';
 
-const GetTests = () => {
+const GetTests = ({ testType }) => {
   const [getTestsModalIsOpen, setGetTestsModalIsOpen] = useState(false);
 
   const handleOpenGetTestsModal = () => {
@@ -18,6 +18,7 @@ const GetTests = () => {
         <GetTestsModal
           getTestsModalIsOpen={getTestsModalIsOpen}
           setGetTestsModalIsOpen={setGetTestsModalIsOpen}
+          testType={testType}
         />
       ) : null}
     </span>

--- a/src/components/GetTests/GetTests.js
+++ b/src/components/GetTests/GetTests.js
@@ -10,9 +10,9 @@ const GetTests = ({ testType }) => {
   };
 
   return (
-    <span>
+    <>
       <button className={styles.getTestBtn} onClick={handleOpenGetTestsModal}>
-        Get Saved Tests
+        Get Tests
       </button>
       {getTestsModalIsOpen ? (
         <GetTestsModal
@@ -21,7 +21,7 @@ const GetTests = ({ testType }) => {
           testType={testType}
         />
       ) : null}
-    </span>
+    </>
   );
 };
 

--- a/src/components/GetTests/GetTests.module.scss
+++ b/src/components/GetTests/GetTests.module.scss
@@ -1,4 +1,5 @@
 @import './../../assets/stylesheets/colors.scss';
+@import '../../assets/stylesheets/fonts.scss';
 
 .navBtn {
   padding: 0;

--- a/src/components/Modals/GetTestsModal.jsx
+++ b/src/components/Modals/GetTestsModal.jsx
@@ -1,6 +1,16 @@
 import React, { useState, useEffect, useContext } from 'react';
 import { AccTestCaseContext } from '../../context/reducers/accTestCaseReducer';
-import { replaceTest } from '../../context/actions/accTestCaseActions';
+import { accReplaceTest } from '../../context/actions/accTestCaseActions';
+import { EndpointTestCaseContext } from '../../context/reducers/endpointTestCaseReducer';
+import { endpointReplaceTest } from '../../context/actions/endpointTestCaseActions';
+import { HooksTestCaseContext } from '../../context/reducers/hooksTestCaseReducer';
+import { hooksReplaceTest } from '../../context/actions/hooksTestCaseActions';
+import { PuppeteerTestCaseContext } from '../../context/reducers/puppeteerTestCaseReducer';
+import { puppeteerReplaceTest } from '../../context/actions/puppeteerTestCaseActions';
+import { ReactTestCaseContext } from '../../context/reducers/reactTestCaseReducer';
+import { reactReplaceTest } from '../../context/actions/reactTestCaseActions';
+import { ReduxTestCaseContext } from '../../context/reducers/reduxTestCaseReducer';
+import { reduxReplaceTest } from '../../context/actions/reduxTestCaseActions';
 
 import ReactModal from 'react-modal';
 import List from '@material-ui/core/List';
@@ -8,9 +18,14 @@ import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import styles from './Modal.module.scss';
 
-const GetTestsModal = ({ getTestsModalIsOpen, setGetTestsModalIsOpen }) => {
+const GetTestsModal = ({ getTestsModalIsOpen, setGetTestsModalIsOpen, testType }) => {
   const [tests, setTests] = useState([]);
   const [accTestCase, dispatchToAccTestCase] = useContext(AccTestCaseContext);
+  const [endpointTestCase, dispatchToEndpointTestCase] = useContext(EndpointTestCaseContext);
+  const [hooksTestCase, dispatchToHooksTestCase] = useContext(HooksTestCaseContext);
+  const [puppeteerTestCase, dispatchToPuppeteerTestCase] = useContext(PuppeteerTestCaseContext);
+  const [reactTestCase, dispatchToReactTestCase] = useContext(ReactTestCaseContext);
+  const [reduxTestCase, dispatchToReduxTestCase] = useContext(ReduxTestCaseContext);
 
   useEffect(() => {
     let isMounted = true;
@@ -25,21 +40,31 @@ const GetTestsModal = ({ getTestsModalIsOpen, setGetTestsModalIsOpen }) => {
   };
 
   const handleGetTests = (isMounted) => {
-    fetch('/getTests')
+    fetch('/getTests/' + testType)
       .then((res) => res.json())
       .then((data) => {
-        console.log(data);
         if (isMounted) setTests(data);
       })
       .catch((err) => console.log(err));
   };
 
   const handleSelectTest = (i) => {
-    console.log('BEFORE DISPATCH:', accTestCase);
-    dispatchToAccTestCase(replaceTest(tests[i].testState));
-    console.log('SAVED TESTSTATE:', tests[i].testState);
-    console.log('AFTER DISPATCH:', accTestCase);
-
+    switch (testType) {
+      case 'acc':
+        dispatchToAccTestCase(accReplaceTest(tests[i].testState));
+      case 'react':
+        dispatchToReactTestCase(reactReplaceTest(tests[i].testState));
+      case 'redux':
+        dispatchToReduxTestCase(reduxReplaceTest(tests[i].testState));
+      case 'hooks':
+        dispatchToHooksTestCase(hooksReplaceTest(tests[i].testState));
+      case 'endpoint test':
+        dispatchToEndpointTestCase(endpointReplaceTest(tests[i].testState));
+      case 'puppeteer':
+        dispatchToPuppeteerTestCase(puppeteerReplaceTest(tests[i].testState));
+      case 'default':
+        console.log('Incorrect input');
+    }
     closeGetTestsModal();
   };
 

--- a/src/components/Modals/GetTestsModal.jsx
+++ b/src/components/Modals/GetTestsModal.jsx
@@ -20,12 +20,12 @@ import styles from './Modal.module.scss';
 
 const GetTestsModal = ({ getTestsModalIsOpen, setGetTestsModalIsOpen, testType }) => {
   const [tests, setTests] = useState([]);
-  const [accTestCase, dispatchToAccTestCase] = useContext(AccTestCaseContext);
-  const [endpointTestCase, dispatchToEndpointTestCase] = useContext(EndpointTestCaseContext);
-  const [hooksTestCase, dispatchToHooksTestCase] = useContext(HooksTestCaseContext);
-  const [puppeteerTestCase, dispatchToPuppeteerTestCase] = useContext(PuppeteerTestCaseContext);
-  const [reactTestCase, dispatchToReactTestCase] = useContext(ReactTestCaseContext);
-  const [reduxTestCase, dispatchToReduxTestCase] = useContext(ReduxTestCaseContext);
+  const [, dispatchToAccTestCase] = useContext(AccTestCaseContext);
+  const [, dispatchToEndpointTestCase] = useContext(EndpointTestCaseContext);
+  const [, dispatchToHooksTestCase] = useContext(HooksTestCaseContext);
+  const [, dispatchToPuppeteerTestCase] = useContext(PuppeteerTestCaseContext);
+  const [, dispatchToReactData] = useContext(ReactTestCaseContext);
+  const [, dispatchToReduxTestCase] = useContext(ReduxTestCaseContext);
 
   useEffect(() => {
     let isMounted = true;
@@ -43,27 +43,35 @@ const GetTestsModal = ({ getTestsModalIsOpen, setGetTestsModalIsOpen, testType }
     fetch('/getTests/' + testType)
       .then((res) => res.json())
       .then((data) => {
-        if (isMounted) setTests(data);
+        if (data.length > 0 && isMounted) setTests(data);
       })
       .catch((err) => console.log(err));
   };
 
   const handleSelectTest = (i) => {
+    console.log(testType + ':', tests[i].testState);
     switch (testType) {
       case 'acc':
         dispatchToAccTestCase(accReplaceTest(tests[i].testState));
+        break;
       case 'react':
-        dispatchToReactTestCase(reactReplaceTest(tests[i].testState));
+        dispatchToReactData(reactReplaceTest(tests[i].testState));
+        break;
       case 'redux':
         dispatchToReduxTestCase(reduxReplaceTest(tests[i].testState));
+        break;
       case 'hooks':
         dispatchToHooksTestCase(hooksReplaceTest(tests[i].testState));
+        break;
       case 'endpoint test':
         dispatchToEndpointTestCase(endpointReplaceTest(tests[i].testState));
+        break;
       case 'puppeteer':
         dispatchToPuppeteerTestCase(puppeteerReplaceTest(tests[i].testState));
-      case 'default':
+        break;
+      default:
         console.log('Incorrect input');
+        break;
     }
     closeGetTestsModal();
   };
@@ -77,8 +85,8 @@ const GetTestsModal = ({ getTestsModalIsOpen, setGetTestsModalIsOpen, testType }
   const renderTestsArray = [];
   for (let i = 0; i < tests.length; i++) {
     renderTestsArray.push(
-      <ListItem button>
-        <ListItemText primary={tests[i].testName} onClick={() => handleSelectTest(i)} />
+      <ListItem button onClick={() => handleSelectTest(i)}>
+        <ListItemText primary={tests[i].testName} />
       </ListItem>
     );
   }
@@ -102,9 +110,13 @@ const GetTestsModal = ({ getTestsModalIsOpen, setGetTestsModalIsOpen, testType }
       </div>
       <div id={styles.body}>
         <div className={styles.root}>
-          <List component='nav' aria-label='saved tests'>
-            {renderTestsArray}
-          </List>
+          {tests.length > 0 ? (
+            <List component='nav' aria-label='saved tests'>
+              {renderTestsArray}
+            </List>
+          ) : (
+            <p style={{ color: 'black' }}>User has no saved tests</p>
+          )}
         </div>
       </div>
     </ReactModal>

--- a/src/components/Modals/UploadTestModal.jsx
+++ b/src/components/Modals/UploadTestModal.jsx
@@ -1,11 +1,21 @@
 import React, { useState, useContext } from 'react';
 import ReactModal from 'react-modal';
 import { AccTestCaseContext } from '../../context/reducers/accTestCaseReducer';
+import { EndpointTestCaseContext } from '../../context/reducers/endpointTestCaseReducer';
+import { HooksTestCaseContext } from '../../context/reducers/hooksTestCaseReducer';
+import { PuppeteerTestCaseContext } from '../../context/reducers/puppeteerTestCaseReducer';
+import { ReactTestCaseContext } from '../../context/reducers/reactTestCaseReducer';
+import { ReduxTestCaseContext } from '../../context/reducers/reduxTestCaseReducer';
 import styles from './Modal.module.scss';
 
 const UploadTestModal = ({ uploadTestModalIsOpen, setUploadTestModalIsOpen, testType }) => {
   const [testName, setTestName] = useState('');
-  const [accTestCase, dispatchToAccTestCase] = useContext(AccTestCaseContext);
+  const [accTestCase] = useContext(AccTestCaseContext);
+  const [endpointTestCase] = useContext(EndpointTestCaseContext);
+  const [hooksTestCase] = useContext(HooksTestCaseContext);
+  const [puppeteerTestCase] = useContext(PuppeteerTestCaseContext);
+  const [reactTestCase] = useContext(ReactTestCaseContext);
+  const [reduxTestCase] = useContext(ReduxTestCaseContext);
 
   const closeUploadModal = () => {
     setUploadTestModalIsOpen(false);
@@ -16,12 +26,39 @@ const UploadTestModal = ({ uploadTestModalIsOpen, setUploadTestModalIsOpen, test
   };
 
   const handleClickSave = () => {
+    let testState;
+    switch (testType) {
+      case 'acc':
+        testState = accTestCase;
+        break;
+      case 'endpoint test':
+        testState = endpointTestCase;
+        break;
+      case 'hooks':
+        testState = hooksTestCase;
+        break;
+      case 'puppeteer':
+        testState = puppeteerTestCase;
+        break;
+      case 'react':
+        testState = reactTestCase;
+        break;
+      case 'redux':
+        testState = reduxTestCase;
+        break;
+      default:
+        testState = [];
+        break;
+    }
+
+    console.log('test being saved:', testState);
+
     fetch('/upload', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ testName, testType, testState: accTestCase }),
+      body: JSON.stringify({ testName, testType, testState }),
     })
       .then((res) => res.json())
       .then((data) => console.log(data))

--- a/src/components/Modals/UploadTestModal.jsx
+++ b/src/components/Modals/UploadTestModal.jsx
@@ -3,7 +3,7 @@ import ReactModal from 'react-modal';
 import { AccTestCaseContext } from '../../context/reducers/accTestCaseReducer';
 import styles from './Modal.module.scss';
 
-const UploadTestModal = ({ uploadTestModalIsOpen, setUploadTestModalIsOpen }) => {
+const UploadTestModal = ({ uploadTestModalIsOpen, setUploadTestModalIsOpen, testType }) => {
   const [testName, setTestName] = useState('');
   const [accTestCase, dispatchToAccTestCase] = useContext(AccTestCaseContext);
 
@@ -21,7 +21,7 @@ const UploadTestModal = ({ uploadTestModalIsOpen, setUploadTestModalIsOpen }) =>
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ testName, testState: accTestCase }),
+      body: JSON.stringify({ testName, testType, testState: accTestCase }),
     })
       .then((res) => res.json())
       .then((data) => console.log(data))

--- a/src/components/PuppeteerTestComponent/PaintTiming/PaintTiming.jsx
+++ b/src/components/PuppeteerTestComponent/PaintTiming/PaintTiming.jsx
@@ -55,6 +55,7 @@ const PaintTiming = ({ paintTiming, index }) => {
               <input
                 type='text'
                 name='first-paint-it'
+                value={paintTiming.firstPaintIt}
                 placeholder='should have its first paint in less than 100 ms'
                 onChange={(e) => handleChangePaintTimingFields(e, 'firstPaintIt')}
               />
@@ -62,6 +63,7 @@ const PaintTiming = ({ paintTiming, index }) => {
                 <input
                   type='text'
                   name='first-paint-benchmark'
+                  value={paintTiming.firstPaintTime}
                   placeholder={100}
                   onChange={(e) => handleChangePaintTimingFields(e, 'firstPaintTime')}
                 />
@@ -80,6 +82,7 @@ const PaintTiming = ({ paintTiming, index }) => {
               <input
                 type='text'
                 name='first-contentful-paint-it'
+                value={paintTiming.FCPIt}
                 placeholder='should have its first meaningful paint in less than 100 ms'
                 onChange={(e) => handleChangePaintTimingFields(e, 'FCPIt')}
               />
@@ -87,6 +90,7 @@ const PaintTiming = ({ paintTiming, index }) => {
                 <input
                   type='text'
                   name='first-contentful-paint-benchmark'
+                  value={paintTiming.FCPtTime}
                   placeholder={100}
                   onChange={(e) => handleChangePaintTimingFields(e, 'FCPtTime')}
                 />
@@ -105,6 +109,7 @@ const PaintTiming = ({ paintTiming, index }) => {
               <input
                 type='text'
                 name='largest-contentful-paint-it'
+                value={paintTiming.LCPIt}
                 placeholder='should have its largest contentful paint in less than 250 ms'
                 onChange={(e) => handleChangePaintTimingFields(e, 'LCPIt')}
               />
@@ -112,6 +117,7 @@ const PaintTiming = ({ paintTiming, index }) => {
                 <input
                   type='text'
                   name='largest-contentful-paint-benchmark'
+                  value={paintTiming.LCPTime}
                   placeholder={250}
                   onChange={(e) => handleChangePaintTimingFields(e, 'LCPTime')}
                 />

--- a/src/components/PuppeteerTestComponent/PuppeteerBrowerSetting/PuppeteerBrowserSetting.jsx
+++ b/src/components/PuppeteerTestComponent/PuppeteerBrowerSetting/PuppeteerBrowserSetting.jsx
@@ -31,12 +31,14 @@ const PuppeteerBrowserSetting = ({ puppeteer, handleChangePuppeteerFields }) => 
         <input
           type='text'
           key={`key${option.id}`}
+          value={option.optionKey}
           id={`key${option.id}`}
           onChange={(e) => handleChangeBrowserOptionFields(e, 'optionKey', option.id)}
         />
         <input
           type='text'
           key={`value${option.id}`}
+          value={option.optionValue}
           id={`value${option.id}`}
           onChange={(e) => handleChangeBrowserOptionFields(e, 'optionValue', option.id)}
         />
@@ -53,6 +55,7 @@ const PuppeteerBrowserSetting = ({ puppeteer, handleChangePuppeteerFields }) => 
           <input
             type='text'
             name='test'
+            value={puppeteer.describe}
             placeholder='eg. Home page performance'
             onChange={(e) => handleChangePuppeteerFields(e, 'describe')}
           />
@@ -65,6 +68,7 @@ const PuppeteerBrowserSetting = ({ puppeteer, handleChangePuppeteerFields }) => 
           <input
             type='text'
             name='url'
+            value={puppeteer.url}
             placeholder='http://localhost:8080/'
             onChange={(e) => handleChangePuppeteerFields(e, 'url')}
           />

--- a/src/components/ReactHooksTestComponent/HookUpdates/HookUpdates.jsx
+++ b/src/components/ReactHooksTestComponent/HookUpdates/HookUpdates.jsx
@@ -74,6 +74,7 @@ const HookUpdates = ({ hookUpdates, index }) => {
                   <input
                     ref={testDescription}
                     type='text'
+                    value={hookUpdates.testName}
                     id={styles.testStatement}
                     onChange={(e) => handleChangeHookUpdatesFields(e, 'testName')}
                   />
@@ -87,6 +88,7 @@ const HookUpdates = ({ hookUpdates, index }) => {
               <input
                 type='text'
                 id='hook'
+                value={hookUpdates.hook}
                 onChange={(e) => handleChangeHookUpdatesFields(e, 'hook')}
                 placeholder='e.g. useToggleCount'
               />
@@ -96,6 +98,7 @@ const HookUpdates = ({ hookUpdates, index }) => {
               <input
                 type='text'
                 id='hookParams'
+                value={hookUpdates.hookParams}
                 placeholder='e.g. false, 0'
                 onChange={(e) => handleChangeHookUpdatesFields(e, 'hookParams')}
               />

--- a/src/components/ReactHooksTestComponent/HooksCallback.jsx
+++ b/src/components/ReactHooksTestComponent/HooksCallback.jsx
@@ -25,6 +25,7 @@ const HooksCallback = ({ callbackFunc, index, id }) => {
           <input
             type='text'
             list='responseProperties'
+            value={callbackFunc.callbackFunc}
             placeholder='e.g. openModal'
             onChange={(e) => handleChangeUpdateCallbackFunc(e, 'callbackFunc')}
           />

--- a/src/components/ReactTestComponent/Action/Action.jsx
+++ b/src/components/ReactTestComponent/Action/Action.jsx
@@ -47,12 +47,18 @@ const Action = ({ statement, statementId, describeId, itId }) => {
       <div id={styles.eventTypeFlexBox}>
         <div id={styles.eventType}>
           <label htmlFor='eventType'>Event Type</label>
-
-          <AutoComplete
+          {/* <AutoComplete
             statement={statement}
             statementType='action'
             dispatchToTestCase={dispatchToReactTestCase}
             id={styles.autoComplete}
+          /> */}
+          <input
+            type='text'
+            id='eventType'
+            value={statement.eventType}
+            onChange={(e) => handleChangeActionFields(e, 'eventType')}
+            placeholder='eg. click, change, keypress'
           />
         </div>
         <div id={styles.eventTypeVal}>
@@ -84,7 +90,11 @@ const Action = ({ statement, statementId, describeId, itId }) => {
             Query Selector
           </label>
           <div id={styles.dropdownFlex}>
-            <select id='queryVariant' onChange={(e) => handleChangeActionFields(e, 'queryVariant')}>
+            <select
+              id='queryVariant'
+              value={statement.queryVariant}
+              onChange={(e) => handleChangeActionFields(e, 'queryVariant')}
+            >
               <option value='' />
               <option value='getBy'>getBy</option>
               <option value='getAllBy'>getAllBy</option>
@@ -102,6 +112,7 @@ const Action = ({ statement, statementId, describeId, itId }) => {
 
             <select
               id='querySelector'
+              value={statement.querySelector}
               onChange={(e) => handleChangeActionFields(e, 'querySelector')}
             >
               <option value='' />
@@ -131,6 +142,7 @@ const Action = ({ statement, statementId, describeId, itId }) => {
           <input
             type='text'
             id='queryValue'
+            value={statement.queryValue}
             onChange={(e) => handleChangeActionFields(e, 'queryValue')}
           />
         </div>

--- a/src/components/ReactTestComponent/Assertion/Assertion.jsx
+++ b/src/components/ReactTestComponent/Assertion/Assertion.jsx
@@ -110,11 +110,11 @@ const Assertion = ({ statement, describeId, itId, statementId }) => {
           <label htmlFor='queryValue' className={styles.queryLabel}>
             Query
           </label>
-          <AutoCompleteMockData
+          {/* <AutoCompleteMockData
             statement={statement}
             dispatchToTestCase={dispatchToReactTestCase}
             statementType='assertion'
-          />
+          /> */}
         </div>
       </div>
       <div>

--- a/src/components/ReactTestComponent/DescribeRenderer/DescribeRenderer.jsx
+++ b/src/components/ReactTestComponent/DescribeRenderer/DescribeRenderer.jsx
@@ -14,8 +14,6 @@ const DescribeRenderer = ({
   handleChangeItStatementText,
   type,
 }) => {
-
-
   const deleteDescribeBlockHandleClick = (e) => {
     e.stopPropagation();
     const describeId = e.target.id;
@@ -27,79 +25,67 @@ const DescribeRenderer = ({
       const describeId = e.target.id;
       dispatcher(deleteDescribeBlock(describeId));
     }
-}
+  };
   const addItStatementHandleClick = (e) => {
     const describeId = e.target.id;
     dispatcher(addItstatement(describeId));
   };
 
   return describeBlocks.allIds.map((id, i) => (
-      <Draggable
-        key={id}
-        draggableId={id}
-        index={i}
-        type="describe"
-      >
-        {(provided) => (
-          <div
-            id={styles.describeBlock}
-            ref={provided.innerRef}
-            {...provided.draggableProps}
-            {...provided.dragHandleProps}
-          >
-            <label htmlFor='describe-label' className={styles.describeLabel}>
-              Describe Block
-            </label>
+    <Draggable key={id} draggableId={id} index={i} type='describe'>
+      {(provided) => (
+        <div
+          id={styles.describeBlock}
+          ref={provided.innerRef}
+          {...provided.draggableProps}
+          {...provided.dragHandleProps}
+        >
+          <label htmlFor='describe-label' className={styles.describeLabel}>
+            Describe Block
+          </label>
 
-            <i
-              tabIndex={0}
-              onKeyPress={deleteReactDescribeBlockOnKeyUp}
-              onClick={deleteDescribeBlockHandleClick}
-              id={id}
-              className={cn('far fa-window-close', styles.describeClose)}
-            ></i>
+          <i
+            tabIndex={0}
+            onKeyPress={deleteReactDescribeBlockOnKeyUp}
+            onClick={deleteDescribeBlockHandleClick}
+            id={id}
+            className={cn('far fa-window-close', styles.describeClose)}
+          ></i>
 
-            <input
-              id={id}
-              className={styles.describeInput}
-              name='describe-label'
-              type='text'
-              placeholder={'The component has basic functionality'}
-              value={describeBlocks.byId[id].text || ''}
-              onChange={handleChangeDescribeText}
-            />
-            <div className={styles.separator}></div>
+          <input
+            id={id}
+            className={styles.describeInput}
+            name='describe-label'
+            type='text'
+            placeholder={'The component has basic functionality'}
+            value={describeBlocks.byId['describe0']?.text}
+            onChange={handleChangeDescribeText}
+          />
+          <div className={styles.separator}></div>
 
-            <Droppable
-              droppableId={"droppableReactIt" + id}
-              type={id}
-            >
-              {(innerProvided) => (
-                <div
-                  ref={innerProvided.innerRef}
-                  {...innerProvided.droppableProps}
-                >
-                  <ItRenderer
-                    type={type}
-                    key={`it-${id}-${i}`}
-                    itStatements={itStatements}
-                    statements={statements}
-                    describeId={id}
-                    handleChangeItStatementText={handleChangeItStatementText}
-                  />
-                  {innerProvided.placeholder}
-                </div>
-              )}
-            </Droppable>
-            <div className={styles.buttonContainer}>
-              <button className={styles.addIt} id={id} onClick={addItStatementHandleClick}>
-                +It Statement
-              </button>
-            </div>
+          <Droppable droppableId={'droppableReactIt' + id} type={id}>
+            {(innerProvided) => (
+              <div ref={innerProvided.innerRef} {...innerProvided.droppableProps}>
+                <ItRenderer
+                  type={type}
+                  key={`it-${id}-${i}`}
+                  itStatements={itStatements}
+                  statements={statements}
+                  describeId={id}
+                  handleChangeItStatementText={handleChangeItStatementText}
+                />
+                {innerProvided.placeholder}
+              </div>
+            )}
+          </Droppable>
+          <div className={styles.buttonContainer}>
+            <button className={styles.addIt} id={id} onClick={addItStatementHandleClick}>
+              +It Statement
+            </button>
           </div>
-
-        )}
-      </Draggable>
+        </div>
+      )}
+    </Draggable>
   ));
 };
 

--- a/src/components/ReactTestComponent/Render/Prop.jsx
+++ b/src/components/ReactTestComponent/Render/Prop.jsx
@@ -20,17 +20,30 @@ const Prop = ({ statementId, propId, propKey, propValue, dispatchToTestCase }) =
     dispatchToTestCase(updateProp(statementId, propId, e.target.value, propValue));
   };
 
+  const handleChangeUpdatePropValue = (e) => {
+    e.stopPropagation();
+    dispatchToTestCase(updateProp(statementId, propId, propKey, e.target.value));
+  };
+
   return (
     <div id={styles.renderPropsFlexBox}>
       <input type='text' id='propKey' value={propKey} onChange={handleChangeUpdatePropKey} />
-      <AutoCompleteMockData
+      <input
+        type='text'
+        id='propValue'
+        value={propValue}
+        onChange={handleChangeUpdatePropValue}
+        placeholder='Enter or select a value.'
+      />
+      {/* <AutoCompleteMockData
         id='propValue'
         propType='prop'
         renderId={statementId}
         propId={propId}
         propKey={propKey}
+        propValue={propValue}
         dispatchToTestCase={dispatchToTestCase}
-      />
+      /> */}
       <img src={minusIcon} alt='delete' onClick={handleClickDeleteProp} />
     </div>
   );

--- a/src/components/ReduxTestComponent/ActionCreator/ActionCreator.jsx
+++ b/src/components/ReduxTestComponent/ActionCreator/ActionCreator.jsx
@@ -49,6 +49,7 @@ const ActionCreator = ({ actionCreator, index }) => {
               <input
                 type='text'
                 id='it'
+                value={actionCreator.it}
                 onChange={(e) => handleChangeActionCreatorFields(e, 'it')}
                 placeholder='e.g.should return expected action'
               />
@@ -61,6 +62,7 @@ const ActionCreator = ({ actionCreator, index }) => {
               <input
                 type='text'
                 id='actionCreatorFunc'
+                value={actionCreator.actionCreatorFunc}
                 onChange={(e) => handleChangeActionCreatorFields(e, 'actionCreatorFunc')}
                 placeholder='e.g. addTodo'
               />
@@ -71,6 +73,7 @@ const ActionCreator = ({ actionCreator, index }) => {
               <input
                 type='text'
                 id='actionType'
+                value={actionCreator.actionType}
                 onChange={(e) => handleChangeActionCreatorFields(e, 'actionType')}
                 placeholder='e.g. ADD_TODO'
               />
@@ -83,6 +86,7 @@ const ActionCreator = ({ actionCreator, index }) => {
               <input
                 type='text'
                 id='payloadKey'
+                value={actionCreator.payloadKey}
                 onChange={(e) => handleChangeActionCreatorFields(e, 'payloadKey')}
                 placeholder='e.g. todo'
               />
@@ -92,6 +96,7 @@ const ActionCreator = ({ actionCreator, index }) => {
               <label htmlFor='payloadType'>Payload Type</label>
               <select
                 id='payloadType'
+                value={actionCreator.payloadType}
                 onChange={(e) => handleChangeActionCreatorFields(e, 'payloadType')}
               >
                 <option value='' />

--- a/src/components/ReduxTestComponent/Middleware/Middleware.jsx
+++ b/src/components/ReduxTestComponent/Middleware/Middleware.jsx
@@ -59,6 +59,7 @@ const Middleware = ({ middleware, index }) => {
                 <label htmlFor='typesFile'>Query Value</label>
                 <select
                   id='queryValue'
+                  value={middleware.queryValue}
                   onChange={(e) => handleChangeMiddlewareFields(e, 'queryValue')}
                 >
                   {' '}
@@ -75,6 +76,7 @@ const Middleware = ({ middleware, index }) => {
                 <label htmlFor='typesFile'>Query Variant</label>
                 <select
                   id='queryVariant'
+                  value={middleware.queryVariant}
                   onChange={(e) => handleChangeMiddlewareFields(e, 'queryVariant')}
                 >
                   <option value='' />
@@ -89,6 +91,7 @@ const Middleware = ({ middleware, index }) => {
                 <label htmlFor='typesFile'>Query Selector</label>
                 <select
                   id='querySelector'
+                  value={middleware.querySelector}
                   onChange={(e) => handleChangeMiddlewareFields(e, 'querySelector')}
                 >
                   <option value='' />
@@ -104,6 +107,7 @@ const Middleware = ({ middleware, index }) => {
               <label htmlFor='typesFile'>Middleware Function</label>
               <input
                 id='queryType'
+                value={middleware.queryType}
                 placeholder='eg. thunk'
                 onChange={(e) => handleChangeMiddlewareFields(e, 'queryType')}
               ></input>

--- a/src/components/ReduxTestComponent/Reducer/Reducer.jsx
+++ b/src/components/ReduxTestComponent/Reducer/Reducer.jsx
@@ -44,6 +44,7 @@ const Reducer = ({ reducer, index }) => {
               <input
                 type='text'
                 id='testStatment'
+                value={reducer.itStatement}
                 placeholder='eg. handles ADD_TODO action properly'
                 onChange={(e) => handleChangeReducerFields(e, 'itStatement')}
               />
@@ -53,6 +54,7 @@ const Reducer = ({ reducer, index }) => {
               <input
                 type='text'
                 id='reducerName'
+                value={reducer.reducerName}
                 placeholder='eg. todoReducer'
                 onChange={(e) => handleChangeReducerFields(e, 'reducerName')}
               />
@@ -64,6 +66,7 @@ const Reducer = ({ reducer, index }) => {
               <input
                 type='text'
                 id='initialState'
+                value={reducer.initialState}
                 placeholder='eg. todosState'
                 onChange={(e) => handleChangeReducerFields(e, 'initialState')}
               />
@@ -73,6 +76,7 @@ const Reducer = ({ reducer, index }) => {
               <input
                 type='text'
                 id='reducerAction'
+                value={reducer.reducerAction}
                 placeholder='eg ADD_TODO'
                 onChange={(e) => handleChangeReducerFields(e, 'reducerAction')}
               />
@@ -84,12 +88,14 @@ const Reducer = ({ reducer, index }) => {
               <input
                 type='text'
                 id='payloadKey'
+                value={reducer.payloadKey}
                 placeholder='Key'
                 onChange={(e) => handleChangeReducerFields(e, 'payloadKey')}
               />
               <input
                 type='text'
                 id='payloadValue'
+                value={reducer.payloadValue}
                 placeholder='Value'
                 onChange={(e) => handleChangeReducerFields(e, 'payloadValue')}
               />
@@ -100,12 +106,14 @@ const Reducer = ({ reducer, index }) => {
                 type='text'
                 placeholder='Key'
                 id='expectedKey'
+                value={reducer.expectedKey}
                 onChange={(e) => handleChangeReducerFields(e, 'expectedKey')}
               />
               <input
                 type='text'
                 placeholder='Value'
                 id='expectedValue'
+                value={reducer.expectedValue}
                 onChange={(e) => handleChangeReducerFields(e, 'expectedValue')}
               />
             </div>

--- a/src/components/ReduxTestComponent/Thunk/Thunk.jsx
+++ b/src/components/ReduxTestComponent/Thunk/Thunk.jsx
@@ -41,6 +41,7 @@ const Async = ({ async, index }) => {
               <input
                 type='text'
                 name='it'
+                value={async.it}
                 placeholder='e.g. store should hold expected action'
                 onChange={(e) => handleChangeAsyncFields(e, 'it')}
               />
@@ -53,6 +54,7 @@ const Async = ({ async, index }) => {
               <input
                 type='text'
                 name='asyncFunction'
+                value={async.asyncFunction}
                 onChange={(e) => handleChangeAsyncFields(e, 'asyncFunction')}
               />
             </div>
@@ -62,6 +64,7 @@ const Async = ({ async, index }) => {
               <input
                 type='text'
                 id='actionType'
+                value={async.actionType}
                 onChange={(e) => handleChangeAsyncFields(e, 'actionType')}
                 placeholder='e.g. ADD_TODO'
               />
@@ -75,6 +78,7 @@ const Async = ({ async, index }) => {
                 <input
                   type='text'
                   name='expectedArg'
+                  value={async.expectedArg}
                   placeholder='e.g. response'
                   onChange={(e) => handleChangeAsyncFields(e, 'expectedArg')}
                 />
@@ -102,6 +106,7 @@ const Async = ({ async, index }) => {
               <input
                 type='text'
                 id='payloadKey'
+                value={async.payloadKey}
                 onChange={(e) => handleChangeAsyncFields(e, 'payloadKey')}
                 placeholder='e.g. id'
               />
@@ -111,6 +116,7 @@ const Async = ({ async, index }) => {
               <div id={styles.dropdownFlex}>
                 <select
                   id='payloadType'
+                  value={async.payloadType}
                   onChange={(e) => handleChangeAsyncFields(e, 'payloadType')}
                 >
                   <option value='' />
@@ -147,6 +153,7 @@ const Async = ({ async, index }) => {
                 <input
                   type='text'
                   name='route'
+                  value={async.route}
                   placeholder='eg. /route'
                   onChange={(e) => handleChangeAsyncFields(e, 'route')}
                 />

--- a/src/components/TestCase/ReactTestCase.jsx
+++ b/src/components/TestCase/ReactTestCase.jsx
@@ -25,7 +25,7 @@ import {
 const ReactTestCase = () => {
   const [reactTestCase, dispatchToReactTestCase] = useReducer(
     reactTestCaseReducer,
-    reactTestCaseState,
+    reactTestCaseState
   );
 
   const { describeBlocks, itStatements, statements } = reactTestCase;
@@ -60,21 +60,21 @@ const ReactTestCase = () => {
     if (!result.destination) return;
     if (result.destination.index === result.source.index) return;
 
-    const list = result.draggableId.includes('describe') ? describeBlocks.allIds : itStatements.allIds[result.type];
-    const func = result.draggableId.includes('describe') ? updateDescribeOrder : updateItStatementOrder;
+    const list = result.draggableId.includes('describe')
+      ? describeBlocks.allIds
+      : itStatements.allIds[result.type];
+    const func = result.draggableId.includes('describe')
+      ? updateDescribeOrder
+      : updateItStatementOrder;
 
-    const reorderedStatements = reorder(
-      list,
-      result.source.index,
-      result.destination.index,
-    );
+    const reorderedStatements = reorder(list, result.source.index, result.destination.index);
     dispatchToReactTestCase(func(reorderedStatements, result.type));
   };
 
   return (
     <ReactTestCaseContext.Provider value={[reactTestCase, dispatchToReactTestCase]}>
       <div id={styles.ReactTestCase}>
-        <div id="head">
+        <div id='head'>
           <ReactTestMenu />
         </div>
 
@@ -89,37 +89,33 @@ const ReactTestCase = () => {
               options={Object.keys(filePathMap)}
             />
           </div>
-          <button type="button" className={styles.mockBtn} onClick={handleAddMockData}>
+          <button type='button' className={styles.mockBtn} onClick={handleAddMockData}>
             <i className={cn(styles.addIcon, 'fas fa-plus')} />
             Mock Data
           </button>
         </div>
 
-        {mockData.length > 0 && (
-          <section id={styles.mockDataHeader}>
-            {mockData.map((data) => {
-              return (
-                <MockData
-                  key={data.id}
-                  mockDatumId={data.id}
-                  dispatchToMockData={dispatchToMockData}
-                  fieldKeys={data.fieldKeys}
-                />
-              );
-            })}
-          </section>
-        )}
+        {mockData
+          ? mockData.length > 0 && (
+              <section id={styles.mockDataHeader}>
+                {mockData.map((data) => {
+                  return (
+                    <MockData
+                      key={data.id}
+                      mockDatumId={data.id}
+                      dispatchToMockData={dispatchToMockData}
+                      fieldKeys={data.fieldKeys}
+                    />
+                  );
+                })}
+              </section>
+            )
+          : null}
 
         <DragDropContext onDragEnd={onDragEnd}>
-          <Droppable
-            droppableId="droppableReactDescribe"
-            type="describe"
-          >
+          <Droppable droppableId='droppableReactDescribe' type='describe'>
             {(provided) => (
-              <div
-                ref={provided.innerRef}
-                {...provided.droppableProps}
-              >
+              <div ref={provided.innerRef} {...provided.droppableProps}>
                 <DecribeRenderer
                   dispatcher={dispatchToReactTestCase}
                   describeBlocks={describeBlocks}
@@ -127,7 +123,7 @@ const ReactTestCase = () => {
                   statements={statements}
                   handleChangeDescribeText={handleChangeDescribeText}
                   handleChangeItStatementText={handleChangeItStatementText}
-                  type="react"
+                  type='react'
                 />
                 {provided.placeholder}
               </div>

--- a/src/components/TestMenu/AccTestMenu.tsx
+++ b/src/components/TestMenu/AccTestMenu.tsx
@@ -69,8 +69,8 @@ const AccTestMenu = () => {
           <button id={styles.example} onClick={openDocs}>
             Need Help?
           </button>
-          <UploadTest />
-          <GetTests />
+          <UploadTest testType="acc" />
+          <GetTests testType="acc" />
           <Modal
             title={title}
             isModalOpen={isModalOpen}

--- a/src/components/TestMenu/EndpointTestMenu.tsx
+++ b/src/components/TestMenu/EndpointTestMenu.tsx
@@ -22,6 +22,8 @@ import {
 import useGenerateTest from '../../context/useGenerateTest';
 import { EndpointTestCaseContext } from '../../context/reducers/endpointTestCaseReducer';
 import { useToggleModal, validateInputs } from './testMenuHooks';
+import UploadTest from '../UploadTest/UploadTest';
+import GetTests from '../GetTests/GetTests';
 
 // child component of EndPointTest menu. has NewTest and Endpoint buttons
 const EndpointTestMenu = () => {
@@ -87,6 +89,8 @@ const EndpointTestMenu = () => {
           <button id={styles.example} onClick={openDocs}>
             Need Help?
           </button>
+          <UploadTest testType="endpoint test" />
+          <GetTests testType="endpoint test" />
           <Modal
             // passing methods down as props to be used when TestModal is opened
             title={title}

--- a/src/components/TestMenu/HooksTestMenu.tsx
+++ b/src/components/TestMenu/HooksTestMenu.tsx
@@ -17,6 +17,8 @@ import Modal from '../Modals/Modal';
 import useGenerateTest from '../../context/useGenerateTest';
 import { HooksTestCaseContext } from '../../context/reducers/hooksTestCaseReducer';
 import { useToggleModal, validateInputs } from './testMenuHooks';
+import UploadTest from '../UploadTest/UploadTest';
+import GetTests from '../GetTests/GetTests';
 
 const HooksTestMenu = () => {
   // Hooks testing docs url
@@ -79,6 +81,8 @@ const HooksTestMenu = () => {
           <button id={styles.example} onClick={openDocs}>
             Need Help?
           </button>
+          <UploadTest testType="hooks" />
+          <GetTests testType="hooks" />
           <Modal
             // passing methods down as props to be used when Modal is opened
             title={title}

--- a/src/components/TestMenu/PuppeteerTestMenu.tsx
+++ b/src/components/TestMenu/PuppeteerTestMenu.tsx
@@ -19,6 +19,8 @@ import {
 import useGenerateTest from '../../context/useGenerateTest';
 import { PuppeteerTestCaseContext } from '../../context/reducers/puppeteerTestCaseReducer';
 import { useToggleModal } from './testMenuHooks';
+import UploadTest from '../UploadTest/UploadTest';
+import GetTests from '../GetTests/GetTests';
 
 const PuppeteerTestMenu = () => {
   const [{ puppeteerStatements }, dispatchToPuppeteerTestCase] = useContext(
@@ -73,6 +75,8 @@ const PuppeteerTestMenu = () => {
           <button id={styles.example} onClick={openDocs}>
             Need Help?
           </button>
+          <UploadTest testType="puppeteer" />
+          <GetTests testType="puppeteer" />
           <Modal
             // passing methods down as props to be used when Modal is opened
             title={title}

--- a/src/components/TestMenu/ReactTestMenu.jsx
+++ b/src/components/TestMenu/ReactTestMenu.jsx
@@ -17,6 +17,8 @@ import {
 } from '../../context/actions/globalActions';
 import { ReactTestCaseContext } from '../../context/reducers/reactTestCaseReducer';
 import { useToggleModal } from './testMenuHooks';
+import UploadTest from '../UploadTest/UploadTest';
+import GetTests from '../GetTests/GetTests';
 
 const ReactTestMenu = () => {
   // React testing docs url
@@ -26,7 +28,8 @@ const ReactTestMenu = () => {
   const { title, isModalOpen, openModal, openScriptModal, closeModal } = useToggleModal('react');
   const [{ mockData }, dispatchToMockData] = useContext(MockDataContext);
   const [reactTestCase, dispatchToReactTestCase] = useContext(ReactTestCaseContext);
-  const [{ projectFilePath, file, exportBool, isTestModalOpen }, dispatchToGlobal] = useContext(GlobalContext);
+  const [{ projectFilePath, file, exportBool, isTestModalOpen }, dispatchToGlobal] =
+    useContext(GlobalContext);
   const generateTest = useGenerateTest('react', projectFilePath);
 
   useEffect(() => {
@@ -58,7 +61,9 @@ const ReactTestMenu = () => {
     <div id='test'>
       <div id={styles.testMenu}>
         <div id={styles.left}>
-          <button onClick={openModal} autoFocus >New Test +</button>
+          <button onClick={openModal} autoFocus>
+            New Test +
+          </button>
           <button onClick={fileHandle}>Preview</button>
           <button id={styles.example} onClick={openScriptModal}>
             Run Test
@@ -66,6 +71,8 @@ const ReactTestMenu = () => {
           <button id={styles.example} onClick={openDocs}>
             Need Help?
           </button>
+          <UploadTest testType='react' />
+          <GetTests testType='react' />
           <Modal
             title={title}
             isModalOpen={isModalOpen}

--- a/src/components/TestMenu/ReduxTestMenu.tsx
+++ b/src/components/TestMenu/ReduxTestMenu.tsx
@@ -22,6 +22,8 @@ import useGenerateTest from '../../context/useGenerateTest.jsx';
 import { GlobalContext } from '../../context/reducers/globalReducer';
 import { ReduxTestCaseContext } from '../../context/reducers/reduxTestCaseReducer';
 import { useToggleModal } from './testMenuHooks';
+import UploadTest from '../UploadTest/UploadTest';
+import GetTests from '../GetTests/GetTests';
 
 const ReduxTestMenu = () => {
   const [{ reduxTestStatement, reduxStatements }, dispatchToReduxTestCase] = useContext(
@@ -85,6 +87,8 @@ const ReduxTestMenu = () => {
           <button id={styles.example} onClick={openDocs}>
             Need Help?
           </button>
+          <UploadTest testType='redux' />
+          <GetTests testType='redux' />
           <Modal
             // passing methods down as props to be used when Modal is opened
             title={title}

--- a/src/components/UploadTest/UploadTest.js
+++ b/src/components/UploadTest/UploadTest.js
@@ -6,7 +6,7 @@ import React, { useState } from 'react';
 import styles from './UploadTest.module.scss';
 import UploadTestModal from '../Modals/UploadTestModal';
 
-const UploadTest = () => {
+const UploadTest = ({ testType }) => {
   const [uploadTestModalIsOpen, setUploadTestModalIsOpen] = useState(false);
 
   const handleOpenUploadTestModal = () => {
@@ -22,6 +22,7 @@ const UploadTest = () => {
         <UploadTestModal
           uploadTestModalIsOpen={uploadTestModalIsOpen}
           setUploadTestModalIsOpen={setUploadTestModalIsOpen}
+          testType={testType}
         />
       ) : null}
     </>

--- a/src/context/actions/accTestCaseActions.ts
+++ b/src/context/actions/accTestCaseActions.ts
@@ -109,7 +109,7 @@ export const createPuppeteerUrl = (puppeteerUrl: string) => ({
   puppeteerUrl,
 });
 
-export const replaceTest = (testState: object) => ({
+export const accReplaceTest = (testState: object) => ({
   type: actionTypes.REPLACE_TEST,
   testState,
 });

--- a/src/context/actions/endpointTestCaseActions.ts
+++ b/src/context/actions/endpointTestCaseActions.ts
@@ -20,6 +20,7 @@ export const actionTypes = {
   UPDATE_ASSERTION: 'UPDATE_ASSERTION',
   TOGGLE_DB: 'TOGGLE_DB',
   UPDATE_DB_FILEPATH: 'UPDATE_DB_FILEPATH',
+  REPLACE_TEST: 'REPLACE_TEST',
 };
 
 // Never used
@@ -138,3 +139,8 @@ export const updateDBFilePath = (dbFilePath: string) => {
     dbFilePath,
   };
 };
+
+export const endpointReplaceTest = (testState: object) => ({
+  type: actionTypes.REPLACE_TEST,
+  testState,
+});

--- a/src/context/actions/hooksTestCaseActions.ts
+++ b/src/context/actions/hooksTestCaseActions.ts
@@ -22,6 +22,7 @@ export const actionTypes = {
   ADD_CALLBACKFUNC: 'ADD_CALLBACKFUNC',
   DELETE_CALLBACKFUNC: 'DELETE_CALLBACKFUNC',
   UPDATE_CALLBACKFUNC: 'UPDATE_CALLBACKFUNC',
+  REPLACE_TEST: 'REPLACE_TEST',
 };
 
 export const toggleHooks = () => ({
@@ -124,3 +125,8 @@ export const toggleTypeof = (index: number) => {
     index,
   };
 };
+
+export const hooksReplaceTest = (testState: object) => ({
+  type: actionTypes.REPLACE_TEST,
+  testState,
+});

--- a/src/context/actions/mockDataActions.js
+++ b/src/context/actions/mockDataActions.js
@@ -52,3 +52,8 @@ export const updateMockDataKey = (mockDatumId, mockDatumKeyId, fieldKey, fieldTy
 export const clearMockData = () => ({
   type: actionTypes.CLEAR_MOCK_DATA,
 });
+
+export const mockReplaceTest = (testState) => ({
+  type: actionTypes.REPLACE_TEST,
+  testState,
+});

--- a/src/context/actions/puppeteerTestCaseActions.ts
+++ b/src/context/actions/puppeteerTestCaseActions.ts
@@ -13,6 +13,7 @@ export const actionTypes = {
   UPDATE_STATEMENTS_ORDER: 'UPDATE_STATEMENTS_ORDER',
   OPEN_INFO_MODAL: 'OPEN_INFO_MODAL',
   CLOSE_INFO_MODAL: 'CLOSE_INFO_MODAL',
+  REPLACE_TEST: 'REPLACE_TEST',
 };
 
 export const togglePuppeteer = () => ({
@@ -75,3 +76,8 @@ export const openInfoModal = () => {
 export const closeInfoModal = () => {
   return { type: actionTypes.CLOSE_INFO_MODAL };
 };
+
+export const puppeteerReplaceTest = (testState: object) => ({
+  type: actionTypes.REPLACE_TEST,
+  testState,
+});

--- a/src/context/actions/reactTestCaseActions.js
+++ b/src/context/actions/reactTestCaseActions.js
@@ -30,6 +30,7 @@ export const actionTypes = {
   CREATE_NEW_TEST: 'CREATE_NEW_TEST',
   OPEN_INFO_MODAL: 'OPEN_INFO_MODAL',
   CLOSE_INFO_MODAL: 'CLOSE_INFO_MODAL',
+  REPLACE_TEST: 'REPLACE_TEST',
 };
 
 /* --------------------------------- Actions -------------------------------- */
@@ -58,7 +59,6 @@ export const updateDescribeOrder = (reorderedDescribe) => ({
   reorderedDescribe,
 });
 
-
 export const addItstatement = (describeId) => ({
   type: actionTypes.ADD_ITSTATEMENT,
   describeId,
@@ -81,7 +81,6 @@ export const updateItStatementOrder = (reorderedIt, describeId) => ({
   reorderedIt,
   describeId,
 });
-
 
 export const addAction = (describeId, itId) => ({
   type: actionTypes.ADD_ACTION,
@@ -112,7 +111,6 @@ export const updateAction = ({
   queryValue,
   suggestions,
 });
-
 
 export const addAssertion = (describeId, itId) => ({
   type: actionTypes.ADD_ASSERTION,
@@ -146,7 +144,6 @@ export const updateAssertion = ({
   suggestions,
 });
 
-
 export const addRender = (describeId, itId) => ({
   type: actionTypes.ADD_RENDER,
   describeId,
@@ -163,7 +160,6 @@ export const updateRenderComponent = (componentName, filePath) => ({
   componentName,
   filePath,
 });
-
 
 export const addProp = (statementId) => ({
   type: actionTypes.ADD_PROP,
@@ -186,7 +182,6 @@ export const updateProp = (statementId, id, propKey, propValue) => ({
   propValue,
 });
 
-
 export const createNewTest = () => ({
   type: actionTypes.CREATE_NEW_TEST,
 });
@@ -198,3 +193,8 @@ export const openInfoModal = () => {
 export const closeInfoModal = () => {
   return { type: actionTypes.CLOSE_INFO_MODAL };
 };
+
+export const reactReplaceTest = (testState) => ({
+  type: actionTypes.REPLACE_TEST,
+  testState,
+});

--- a/src/context/actions/reduxTestCaseActions.ts
+++ b/src/context/actions/reduxTestCaseActions.ts
@@ -124,3 +124,8 @@ export const openInfoModal = () => {
 export const closeInfoModal = () => {
   return { type: actionTypes.CLOSE_INFO_MODAL };
 };
+
+export const reduxReplaceTest = (testState: object) => ({
+  type: actionTypes.REPLACE_TEST,
+  testState,
+});

--- a/src/context/reducers/endpointTestCaseReducer.ts
+++ b/src/context/reducers/endpointTestCaseReducer.ts
@@ -8,7 +8,7 @@ import {
   Header,
 } from '../../utils/endpointTypes';
 
-export const EndpointTestCaseContext: any = createContext(null);
+export const EndpointTestCaseContext: any = createContext([]);
 
 const newAssertion: Assertion = {
   id: 0,
@@ -202,6 +202,10 @@ export const endpointTestCaseReducer = (state: EndpointTestCaseState, action: Ac
         ...state,
         dbFilePath: action.dbFilePath,
       };
+    case actionTypes.REPLACE_TEST: {
+      const { testState } = action;
+      return testState;
+    }
     default:
       return state;
   }

--- a/src/context/reducers/hooksTestCaseReducer.ts
+++ b/src/context/reducers/hooksTestCaseReducer.ts
@@ -1,7 +1,7 @@
 import { createContext } from 'react';
 import { HooksTestCaseState, Assertion, HooksAction, Hooks, Callback } from '../../utils/hooksTypes';
 
-export const HooksTestCaseContext: any = createContext(null);
+export const HooksTestCaseContext: any = createContext([]);
 
 const newAssertion: Assertion = {
   id: 0,
@@ -293,6 +293,9 @@ export const hooksTestCaseReducer = (state: HooksTestCaseState, action: HooksAct
         ...state,
         hooksStatements,
       };
+    case 'REPLACE_TEST': {
+      return action.testState;
+    }
     default:
       return state;
   }

--- a/src/context/reducers/mockDataReducer.js
+++ b/src/context/reducers/mockDataReducer.js
@@ -1,7 +1,7 @@
 import { createContext } from 'react';
 import { actionTypes } from '../actions/mockDataActions';
 
-export const MockDataContext = createContext(null);
+export const MockDataContext = createContext([]);
 
 export const mockDataState = {
   mockData: [],
@@ -109,6 +109,10 @@ export const mockDataReducer = (state, action) => {
         mockData: [],
         hasMockData: false,
       };
+    case actionTypes.REPLACE_TEST: {
+      const { testState } = action;
+      return testState;
+    }
     default:
       return state;
   }

--- a/src/context/reducers/puppeteerTestCaseReducer.ts
+++ b/src/context/reducers/puppeteerTestCaseReducer.ts
@@ -1,7 +1,7 @@
 import { createContext } from 'react';
 import { PuppeteerTestCaseState, PuppeteerAction } from '../../utils/puppeteerTypes';
 
-export const PuppeteerTestCaseContext = createContext<any>(null);
+export const PuppeteerTestCaseContext = createContext<any>([]);
 
 export const puppeteerTestCaseState = {
   puppeteerStatements: [
@@ -184,6 +184,9 @@ export const puppeteerTestCaseReducer = (
         ...state,
         modalOpen: false,
       };
+    case 'REPLACE_TEST': {
+      return action.testState;
+    }
     default:
       return state;
   }

--- a/src/context/reducers/reactTestCaseReducer.js
+++ b/src/context/reducers/reactTestCaseReducer.js
@@ -350,15 +350,8 @@ export const reactTestCaseReducer = (state, action) => {
       };
     }
     case actionTypes.UPDATE_ACTION: {
-      const {
-        id,
-        eventType,
-        eventValue,
-        queryVariant,
-        querySelector,
-        queryValue,
-        suggestions,
-      } = action;
+      const { id, eventType, eventValue, queryVariant, querySelector, queryValue, suggestions } =
+        action;
       const byId = { ...statements.byId };
       const oldStatement = { ...statements.byId[id] };
       const newStatement = {
@@ -595,6 +588,9 @@ export const reactTestCaseReducer = (state, action) => {
         ...state,
         modalOpen: false,
       };
+    }
+    case actionTypes.REPLACE_TEST: {
+      return action.testState;
     }
     default:
       return state;

--- a/src/context/reducers/reduxTestCaseReducer.ts
+++ b/src/context/reducers/reduxTestCaseReducer.ts
@@ -1,7 +1,7 @@
 import { createContext } from 'react';
 import { actionTypes, ReduxTestCaseState } from '../../utils/reduxTypes';
 
-export const ReduxTestCaseContext: any = createContext(null);
+export const ReduxTestCaseContext: any = createContext([]);
 
 /* here we create context for the redux test case. Dont provide it a default value (only used when you dont hve a provider for it), use null instead */
 /* initial state for testCase */
@@ -299,7 +299,10 @@ export const reduxTestCaseReducer = (state = reduxTestCaseState, action: any) =>
         ...state,
         modalOpen: false,
       };
-
+    case actionTypes.REPLACE_TEST: {
+      const { testState } = action;
+      return testState;
+    }
     default:
       return state;
   }

--- a/src/pages/TestFile/TestFile.jsx
+++ b/src/pages/TestFile/TestFile.jsx
@@ -133,9 +133,9 @@ const TestFile = () => {
             <button id={styles.save} onClick={() => handleToggle('redux')}>
               Redux
             </button>
-            <button id={styles.save} onClick={() => handleToggle('vue')}>
+            {/* <button id={styles.save} onClick={() => handleToggle('vue')}>
               Vue
-            </button>
+            </button> */}
           </span>
         </div>
       </ReactModal>
@@ -189,14 +189,16 @@ const TestFile = () => {
           </AccTestCaseContext.Provider>
         </section>
       )}
-      //incomplete functionality: this is wired to go to a react test for now
-      {testCase === 'vue' && (
-        <section>
-          <MockDataContext.Provider value={[mockData, dispatchToMockData]}>
-            <ReactTestCase />
-          </MockDataContext.Provider>
-        </section>
-      )}
+      {/* {
+        //incomplete functionality: this is wired to go to a react test for now
+        testCase === 'vue' && (
+          <section>
+            <MockDataContext.Provider value={[mockData, dispatchToMockData]}>
+              <ReactTestCase />
+            </MockDataContext.Provider>
+          </section>
+        )
+      } */}
 
       {testCase === '' && (
         <Fragment>

--- a/src/utils/hooksTypes.ts
+++ b/src/utils/hooksTypes.ts
@@ -46,7 +46,8 @@ export type HooksAction =
         | 'ADD_HOOK_UPDATES'
         | 'CREATE_NEW_HOOKS_TEST'
         | 'OPEN_INFO_MODAL'
-        | 'CLOSE_INFO_MODAL';
+        | 'CLOSE_INFO_MODAL'
+        | 'REPLACE_TEST';
     }
   | { type: 'UPDATE_HOOKS_TEST_STATEMENT'; hooksTestStatement: string }
   | { type: 'DELETE_CONTEXT' | 'DELETE_HOOK_UPDATES' | 'TOGGLE_TYPEOF' | 'ADD_CALLBACKFUNC'; id: number }

--- a/src/utils/puppeteerTypes.ts
+++ b/src/utils/puppeteerTypes.ts
@@ -41,10 +41,11 @@ export type PuppeteerAction =
         | 'CREATE_NEW_PUPPETEER_TEST'
         | 'ADD_PUPPETEER_PAINT_TIMING'
         | 'OPEN_INFO_MODAL'
-        | 'CLOSE_INFO_MODAL';
+        | 'CLOSE_INFO_MODAL'
+        | 'REPLACE_TEST'; testState: any
     }
   | { type: 'DELETE_PUPPETEER_TEST' | 'ADD_BROWSER_OPTIONS'; id: number }
   | { type: 'DELETE_BROWSER_OPTION'; id: number; optionId: number }
   | { type: 'UPDATE_PAINT_TIMING'; id: number; field: string; value: string }
   | { type: 'UPDATE_BROWSER_OPTION'; id: number; field: string; value: string; optionId: number }
-  | { type: 'UPDATE_STATEMENTS_ORDER'; draggableStatements: Array<object> };
+  | { type: 'UPDATE_STATEMENTS_ORDER'; draggableStatements: Array<object> }

--- a/src/utils/reduxTypes.ts
+++ b/src/utils/reduxTypes.ts
@@ -22,6 +22,7 @@ export const actionTypes = {
   CREATE_NEW_REDUX_TEST: 'CREATE_NEW_REDUX_TEST',
   OPEN_INFO_MODAL: 'OPEN_INFO_MODAL',
   CLOSE_INFO_MODAL: 'CLOSE_INFO_MODAL',
+  REPLACE_TEST: 'REPLACE_TEST',
 };
 
 interface ToggleReduxAction {
@@ -304,4 +305,4 @@ export type ReduxActionTypes =
   | UpdateTypesFilePathAction
   | UpdateReducerFilePathAction
   | UpdateMiddlewaresFilePathAction
-  | CreateNewReduxTestAction;
+  | CreateNewReduxTestAction


### PR DESCRIPTION
1. Modified mongoose 'testState' schema to save current type of test
2. Added tests of corresponding type to response object when /getTests route is called 
2. Added action logic to all test reducers to replace old state with new state fetched from DB
3. GetTestModal and UploadTestModal both make correct requests to server, as well as dispatch relevant actions to update state
4. Updated all test case components to reflect state changes after replace test actions are dispatched
5. Fixed JSX to display button that accurately displays functionality